### PR TITLE
fix(sdk): Type async column generate functions

### DIFF
--- a/packages/seed/src/core/codegen/generateClientTypes.ts
+++ b/packages/seed/src/core/codegen/generateClientTypes.ts
@@ -106,7 +106,7 @@ type ColumnValueCallbackContext<TScalars> = {
 /**
  * helper type to get the possible values of a scalar field
  */
-type ColumnValue<T, TScalars> = T | ((ctx: ColumnValueCallbackContext<TScalars>) => T);
+type ColumnValue<T, TScalars> = T | ((ctx: ColumnValueCallbackContext<TScalars>) => T | Promise<T>);
 
 /**
  * helper type to map a record of scalars to a record of ColumnValue


### PR DESCRIPTION
At the moment we support them at runtime, but do not have types for them.