### PR TITLE
feat: Add maxLength to dataModel

### DIFF
--- a/packages/seed/src/dialects/postgres/introspect/introspectionToDataModel.ts
+++ b/packages/seed/src/dialects/postgres/introspect/introspectionToDataModel.ts
@@ -243,6 +243,7 @@ export function introspectionToDataModel(
         sequence,
         hasDefaultValue: column.default !== null,
         isId: Boolean(primaryKeysColumnsNames.get(column.name)),
+        maxLength: column.maxLength,
       };
       fields.push(field);
     }


### PR DESCRIPTION
We were already collecting the maxLength for columns, we also already have the `maxLength` property on the type for data model scalar fields. We just needed to put them on the data model when converting from introspection result to data model for postgres (for sqlite there are no relevant char limits to consider).