### PR TITLE
tests: Port over e2e: Core behaviour (e2e.test.ts)

### DIFF
--- a/packages/seed/e2e/e2e.test.ts
+++ b/packages/seed/e2e/e2e.test.ts
@@ -271,6 +271,161 @@ for (const dialect of Object.keys(adapters) as Array<Dialect>) {
         expect(bookings[0].student_id).toEqual(students[0].student_id);
         expect(bookings[1].student_id).toEqual(students[0].student_id);
       });
+
+      test("works without seed.config.ts", async () => {
+        const { db } = await setupProject({
+          adapter,
+          databaseSchema: `
+          CREATE TABLE "Organization" (
+            "id" uuid not null primary key
+          );
+        `,
+          snapletConfig: null,
+          seedScript: `
+          import { createSeedClient } from '#seed'
+          const seed = await createSeedClient()
+          await seed.organizations((x) => x(2))
+        `,
+        });
+
+        expect((await db.query('select * from "Organization"')).length).toEqual(
+          2,
+        );
+      });
+
+      test("default field ordering for `data` in generate callback", async () => {
+        const { db } = await setupProject({
+          adapter,
+          databaseSchema: `
+          CREATE TABLE "Organization" (
+            "id" serial not null primary key
+          );
+          CREATE TABLE "Member" (
+            "result" text not null,
+            "id" serial not null primary key,
+            "organizationId" int not null references "Organization"("id"),
+            "fromPlanOptions" text not null,
+            "fromPlanDescription1" text not null,
+            "fromPlanDescription2" text not null,
+            "fromClientOptions" text not null,
+            "notInPlanDescription" text not null
+          );
+        `,
+          seedScript: `
+          import { createSeedClient } from "#seed"
+
+          const seed = await createSeedClient({
+            models: {
+              members: {
+                data: {
+                  fromClientOptions: () => 'fromClientOptionsValue'
+                }
+              }
+            }
+          })
+
+          await seed.members((x) => x(1, {
+            fromPlanDescription1: () => 'fromPlanDescription1Value',
+            fromPlanDescription2: () => 'fromPlanDescription2Value',
+            result: ({ data }) => JSON.stringify(Object.keys(data))
+          }), {
+            models: {
+              members: {
+                data: {
+                  fromPlanOptions: () => 'fromPlanOptionsValue'
+                }
+              }
+            }
+          })
+        `,
+        });
+
+        const [row] = await db.query<{ result: string }>(
+          'SELECT result FROM "Member"',
+        );
+
+        expect(JSON.parse(row.result)).toEqual([
+          "organizationId",
+          "id",
+          "notInPlanDescription",
+          "fromClientOptions",
+          "fromPlanOptions",
+          "fromPlanDescription1",
+          "fromPlanDescription2",
+        ]);
+      });
+
+      test("compatibility with externally inserted data", async () => {
+        const schema: Partial<Record<"default" | Dialect, string>> = {
+          default: `
+            CREATE TABLE "User" (
+              "user_id" SERIAL PRIMARY KEY
+            );
+            `,
+          sqlite: `
+            CREATE TABLE "User" (
+              "user_id" INTEGER PRIMARY KEY AUTOINCREMENT
+            );
+          `,
+        };
+
+        // context(justinvdm, 24 Jan 2024): We use `user_id` as a field name to
+        // make sure any field aliasing / renaming we do (e.g. to camel case)
+        // does not affect how sequences are found and updated
+        const { db, runSeedScript } = await setupProject({
+          adapter,
+          databaseSchema: schema[dialect] ?? schema.default,
+        });
+
+        await db.run('insert into "User" DEFAULT VALUES');
+
+        await runSeedScript(`
+          import { createSeedClient, db } from "#seed"
+
+          const seed = await createSeedClient()
+
+          await db.run('insert into "User" DEFAULT VALUES')
+          await db.run('insert into "User" DEFAULT VALUES')
+
+          await seed.$transaction(async seed => {
+            await seed.users(x => x(2))
+          })
+        `);
+
+        const rows = await db.query('select * from "User"');
+
+        expect(rows).toEqual([
+          { user_id: 1 },
+          { user_id: 2 },
+          { user_id: 3 },
+          { user_id: 4 },
+          { user_id: 5 },
+        ]);
+      });
+
+      test("seeds are unique per seed.<modelName> call", async () => {
+        const { db } = await setupProject({
+          adapter,
+          databaseSchema: `
+            create table users (
+              id uuid not null primary key,
+              confirmation_token text
+            );
+
+            create unique index confirmation_token_idx on users (confirmation_token);
+          `,
+          seedScript: `
+        import { createSeedClient } from "#seed"
+        const seed = await createSeedClient()
+        await seed.$resetDatabase()
+        await seed.users([{}])
+        await seed.users([{}])
+      `,
+        });
+
+        const rows = await db.query('select * from "users"');
+        expect(rows.length).toEqual(2);
+      });
     },
     {
       timeout: 45000,

--- a/packages/seed/test/adapters.ts
+++ b/packages/seed/test/adapters.ts
@@ -43,14 +43,18 @@ export const adapters = {
       }) => `
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { createSeedClient as baseCreateSeedClient } from "${generateOutputIndexPath}";
+import { createDrizzleORMPgClient } from "@snaplet/seed/dialects/postgres/adapters"
+import { createSeedClient as baseCreateSeedClient } from "${generateOutputIndexPath}"
 
 const client = postgres("${connectionString}")
-const db = drizzle(client);
+
+const drizzleDb = drizzle(client)
+
+export const db = createDrizzleORMPgClient(drizzleDb)
 
 export const end = () => client.end()
 
-export const createSeedClient = (options?: Parameters<typeof baseCreateSeedClient>[1]) => baseCreateSeedClient(db, options)
+export const createSeedClient = (options?: Parameters<typeof baseCreateSeedClient>[1]) => baseCreateSeedClient(drizzleDb, options)
 `,
     };
   },
@@ -70,15 +74,18 @@ export const createSeedClient = (options?: Parameters<typeof baseCreateSeedClien
       }) => `
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { createSeedClient as baseCreateSeedClient } from "${generateOutputIndexPath}";
+import { createDrizzleORMSqliteClient } from "@snaplet/seed/dialects/sqlite/adapters"
+import { createSeedClient as baseCreateSeedClient } from "${generateOutputIndexPath}"
 
 const client = new Database(new URL("${connectionString}").pathname, { fileMustExist: false })
 
-const db = drizzle(client);
+const drizzleDb = drizzle(client)
+
+export const db = createDrizzleORMSqliteClient(drizzleDb)
 
 export const end = () => client.close()
 
-export const createSeedClient = (options?: Parameters<typeof baseCreateSeedClient>[1]) => baseCreateSeedClient(db, options)
+export const createSeedClient = (options?: Parameters<typeof baseCreateSeedClient>[1]) => baseCreateSeedClient(drizzleDb, options)
 `,
     };
   },

--- a/packages/seed/test/runSeedScript.ts
+++ b/packages/seed/test/runSeedScript.ts
@@ -1,6 +1,6 @@
 import c from "ansi-colors";
 import { execa } from "execa";
-import { mkdirp, remove, symlink, writeFile } from "fs-extra";
+import { mkdirp, symlink, writeFile } from "fs-extra";
 import path from "node:path";
 import tmp from "tmp-promise";
 import { expect } from "vitest";
@@ -100,46 +100,39 @@ export const runSeedScript = async ({
   );
   await writeFile(scriptPath, script);
 
-  try {
-    const typecheckResult = execa("tsc", ["--project", tsConfigPath], {
-      stderr: "pipe",
-      stdout: "pipe",
-      extendEnv: true,
-      cwd,
-      env: {
-        DEBUG_COLORS: "1",
-        ...env,
-      },
-    });
-    typecheckResult.stdout?.on("data", (chunk: Buffer) => {
-      debugScriptOutput(chunk.toString().trim());
-    });
-    typecheckResult.stderr?.on("data", (chunk: Buffer) => {
-      debugScriptOutput(chunk.toString().trim());
-    });
-    await typecheckResult;
+  const typecheckResult = execa("tsc", ["--project", tsConfigPath], {
+    stderr: "pipe",
+    stdout: "pipe",
+    extendEnv: true,
+    cwd,
+    env: {
+      DEBUG_COLORS: "1",
+      ...env,
+    },
+  });
+  typecheckResult.stdout?.on("data", (chunk: Buffer) => {
+    debugScriptOutput(chunk.toString().trim());
+  });
+  typecheckResult.stderr?.on("data", (chunk: Buffer) => {
+    debugScriptOutput(chunk.toString().trim());
+  });
+  await typecheckResult;
 
-    const result = execa("tsx", ["--conditions=development", scriptPath], {
-      stderr: "pipe",
-      stdout: "pipe",
-      extendEnv: true,
-      env: {
-        DEBUG_COLORS: "1",
-        ...env,
-      },
-    });
-    result.stdout?.on("data", (chunk: Buffer) => {
-      debugScriptOutput(chunk.toString().trim());
-    });
-    result.stderr?.on("data", (chunk: Buffer) => {
-      debugScriptOutput(chunk.toString().trim());
-    });
+  const result = execa("tsx", ["--conditions=development", scriptPath], {
+    stderr: "pipe",
+    stdout: "pipe",
+    extendEnv: true,
+    env: {
+      DEBUG_COLORS: "1",
+      ...env,
+    },
+  });
+  result.stdout?.on("data", (chunk: Buffer) => {
+    debugScriptOutput(chunk.toString().trim());
+  });
+  result.stderr?.on("data", (chunk: Buffer) => {
+    debugScriptOutput(chunk.toString().trim());
+  });
 
-    return await result;
-  } catch (e) {
-    throw e;
-  } finally {
-    await remove(scriptPath);
-    await remove(pkgPath);
-  }
+  return result;
 };


### PR DESCRIPTION
* [works without seed.config.ts](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1512)
* [default field ordering for data in generate callback](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1676)
* [compatibility with externally inserted data](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1740)
* [seeds are unique per seed.<modelName> call](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L2151)