### PR TITLE
tests: Port over e2e: @snaplet/seed programmatic API (e2e.api.test.ts)

### DIFF
--- a/packages/seed/e2e/e2e.api.test.ts
+++ b/packages/seed/e2e/e2e.api.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "vitest";
+import { type Dialect, adapters } from "#test/adapters.js";
+import { setupProject } from "#test/setupProject.js";
+
+for (const dialect of Object.keys(adapters) as Array<Dialect>) {
+  const adapter = await adapters[dialect]();
+
+  describe.concurrent(
+    `e2e: api: ${dialect}`,
+    () => {
+      test("seed.$reset works as expected", async () => {
+        const schema: Partial<Record<"default" | Dialect, string>> = {
+          default: `
+            CREATE TABLE "user" (
+              "id" SERIAL PRIMARY KEY,
+              "email" text NOT NULL
+            );
+          `,
+          sqlite: `
+            CREATE TABLE "user" (
+              "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+              "email" text NOT NULL
+            );
+            `,
+        };
+
+        const { db } = await setupProject({
+          adapter,
+          databaseSchema: schema[dialect] ?? schema.default,
+          seedScript: `
+          import { createSeedClient } from "#seed"
+
+          const seed = await createSeedClient()
+          await seed.users((x) => x(2))
+
+          seed.$reset()
+
+          try {
+            await seed.users((x) => x(2))
+          } catch (e) {
+            console.log(e)
+          }
+        `,
+        });
+
+        // Check if the tables have been populated with the correct number of entries
+        expect((await db.query('SELECT * FROM "user"')).length).toEqual(2);
+      });
+
+      test("seed.$transaction works as expected", async () => {
+        const schema: Partial<Record<"default" | Dialect, string>> = {
+          default: `
+            CREATE TABLE "user" (
+              "id" SERIAL PRIMARY KEY,
+              "email" text NOT NULL
+            );
+          `,
+          sqlite: `
+            CREATE TABLE "user" (
+              "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+              "email" text NOT NULL
+            );
+            `,
+        };
+
+        const { db } = await setupProject({
+          adapter,
+          databaseSchema: schema[dialect] ?? schema.default,
+          seedScript: `
+          import { createSeedClient } from "#seed"
+
+          const seed = await createSeedClient()
+          await seed.$transaction(async (seed) => {
+            await seed.users((x) => x(3))
+          })
+
+          try {
+            await seed.users((x) => x(3))
+          } catch (e) {
+            console.log(e)
+          }
+        `,
+        });
+
+        // Check if the tables have been populated with the correct number of entries
+        expect((await db.query('SELECT * FROM "user"')).length).toEqual(3);
+      });
+
+      test("async column generate callbacks", async () => {
+        const { db } = await setupProject({
+          adapter,
+          databaseSchema: `
+          CREATE TABLE "User" (
+            "id" uuid not null,
+            "fullName" text not null
+          );
+        `,
+          seedScript: `
+          import { createSeedClient } from '#seed'
+          const seed = await createSeedClient()
+          await seed.users([{
+            fullName: () => Promise.resolve('Foo Bar')
+          }])
+        `,
+        });
+
+        const [{ fullName }] = await db.query<{ fullName: string }>(
+          'select * from "User"',
+        );
+
+        expect(fullName).toEqual("Foo Bar");
+      });
+
+      describe("$resetDatabase", () => {
+        test("should reset all tables per default", async () => {
+          const schema: Partial<Record<"default" | Dialect, string>> = {
+            default: `
+              CREATE TABLE "Team" (
+                "id" SERIAL PRIMARY KEY
+              );
+              CREATE TABLE "Player" (
+                "id" BIGSERIAL PRIMARY KEY,
+                "teamId" integer NOT NULL REFERENCES "Team"("id"),
+                "name" text NOT NULL
+              );
+              CREATE TABLE "Game" (
+                "id" INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+              );
+            `,
+            sqlite: `
+              CREATE TABLE "Team" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT
+              );
+              CREATE TABLE "Player" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+                "teamId" integer NOT NULL REFERENCES "Team"("id"),
+                "name" text NOT NULL
+              );
+              CREATE TABLE "Game" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT
+              );
+            `,
+          };
+
+          const seedScript = `
+        import { createSeedClient } from '#seed'
+        const seed = await createSeedClient()
+        await seed.$resetDatabase()
+        await seed.teams((x) => x(2, {
+          players: (x) => x(3)
+        }));
+        await seed.games((x) => x(3));
+      `;
+          const { db, runSeedScript } = await setupProject({
+            adapter,
+            databaseSchema: schema[dialect] ?? schema.default,
+            seedScript,
+          });
+          expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+          expect((await db.query('SELECT * FROM "Team"')).length).toEqual(2);
+          expect((await db.query('SELECT * FROM "Game"')).length).toEqual(3);
+          // Should be able to re-run the seed script again thanks to the $resetDatabase
+          await runSeedScript(seedScript);
+          expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+          expect((await db.query('SELECT * FROM "Team"')).length).toEqual(2);
+          expect((await db.query('SELECT * FROM "Game"')).length).toEqual(3);
+        });
+
+        test("should not reset config excluded table", async () => {
+          const schema: Partial<Record<"default" | Dialect, string>> = {
+            default: `
+              CREATE TABLE "A" (
+                "id" SERIAL PRIMARY KEY
+              );
+
+              CREATE TABLE "B" (
+                "id" SERIAL PRIMARY KEY
+              );
+            `,
+            sqlite: `
+              CREATE TABLE "A" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT
+              );
+              CREATE TABLE "B" (
+                "id" INTEGER PRIMARY KEY AUTOINCREMENT
+              );
+            `,
+          };
+
+          const snapletConfig: Partial<Record<"default" | Dialect, string>> = {
+            default: `
+              import { defineConfig } from "@snaplet/seed/config";
+
+              export default defineConfig({
+                select: {
+                  "B": false,
+                },
+              })
+            `,
+            postgres: `
+              import { defineConfig } from "@snaplet/seed/config";
+
+              export default defineConfig({
+                select: {
+                  "public.B": false,
+                },
+              })
+            `,
+          };
+
+          const { db, runSeedScript } = await setupProject({
+            adapter,
+            snapletConfig: snapletConfig[dialect] ?? snapletConfig.default,
+            databaseSchema: schema[dialect] ?? schema.default,
+          });
+
+          await db.run(`INSERT INTO "A" DEFAULT VALUES`);
+          await db.run(`INSERT INTO "A" DEFAULT VALUES`);
+
+          await db.run(`INSERT INTO "B" DEFAULT VALUES`);
+          await db.run(`INSERT INTO "B" DEFAULT VALUES`);
+
+          await runSeedScript(`
+            import { createSeedClient } from '#seed'
+
+            const seed = await createSeedClient()
+            await seed.$resetDatabase()
+          `);
+
+          expect((await db.query('SELECT * FROM "A"')).length).toBe(0);
+          expect((await db.query('SELECT * FROM "B"')).length).toBe(2);
+        });
+      });
+    },
+    {
+      timeout: 45000,
+    },
+  );
+}

--- a/packages/seed/e2e/e2e.postgres.test.ts
+++ b/packages/seed/e2e/e2e.postgres.test.ts
@@ -57,6 +57,208 @@ describe.concurrent(
       // Check if the tables have been populated with the correct number of entries
       expect((await db.query('SELECT * FROM "user"')).length).toEqual(2);
     });
+
+    describe("$resetDatabase", () => {
+      test("should reset all schemas and tables per default", async () => {
+        const seedScript = `
+        import { createSeedClient } from '#seed'
+        const seed = await createSeedClient()
+        await seed.$resetDatabase()
+        await seed.teams((x) => x(2, {
+          players: (x) => x(3)
+        }));
+        await seed.games((x) => x(3));
+      `;
+        const { db, runSeedScript } = await setupProject({
+          adapter,
+          databaseSchema: `
+            CREATE SCHEMA IF NOT EXISTS hdb_catalog;
+            CREATE TABLE hdb_catalog."SystemSettings" (
+              "settingKey" VARCHAR(255) PRIMARY KEY,
+              "settingValue" TEXT NOT NULL
+            );
+
+            CREATE TABLE hdb_catalog."AuditLog" (
+              "logId" SERIAL PRIMARY KEY,
+              "action" TEXT NOT NULL,
+              "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+              "userId" INTEGER
+            );
+
+            INSERT INTO hdb_catalog."SystemSettings" ("settingKey", "settingValue") VALUES
+            ('theme', 'dark'),
+            ('retryInterval', '30');
+
+            INSERT INTO hdb_catalog."AuditLog" ("action", "userId") VALUES
+            ('System Start', NULL),
+            ('Initial Configuration', NULL);
+
+            CREATE TABLE "Team" (
+              "id" SERIAL PRIMARY KEY
+            );
+            CREATE TABLE "Player" (
+              "id" BIGSERIAL PRIMARY KEY,
+              "teamId" integer NOT NULL REFERENCES "Team"("id"),
+              "name" text NOT NULL
+            );
+            CREATE TABLE "Game" (
+              "id" INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+            );
+          `,
+          seedScript,
+        });
+        expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+        expect(
+          (await db.query('SELECT * FROM hdb_catalog."AuditLog"')).length,
+        ).toEqual(0);
+        expect(
+          (await db.query('SELECT * FROM hdb_catalog."SystemSettings"')).length,
+        ).toEqual(0);
+        // Should be able to re-run the seed script again thanks to the $resetDatabase
+        await runSeedScript(seedScript);
+        expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+      });
+
+      test("should not reset config excluded schema", async () => {
+        const snapletConfig = `
+        import { defineConfig } from "@snaplet/seed/config";
+
+        export default defineConfig({
+          select: {
+            'hdb_catalog.*': false,
+          },
+        })
+  `;
+        const seedScript = `
+        import { createSeedClient } from "#seed"
+        const seed = await createSeedClient()
+        await seed.$resetDatabase()
+        await seed.teams((x) => x(2, {
+          players: (x) => x(3)
+        }));
+        await seed.games((x) => x(3));
+      `;
+        const { db, runSeedScript } = await setupProject({
+          adapter,
+          databaseSchema: `
+            CREATE SCHEMA IF NOT EXISTS hdb_catalog;
+            CREATE TABLE hdb_catalog."SystemSettings" (
+              "settingKey" VARCHAR(255) PRIMARY KEY,
+              "settingValue" TEXT NOT NULL
+            );
+
+            CREATE TABLE hdb_catalog."AuditLog" (
+              "logId" SERIAL PRIMARY KEY,
+              "action" TEXT NOT NULL,
+              "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+              "userId" INTEGER
+            );
+
+            INSERT INTO hdb_catalog."SystemSettings" ("settingKey", "settingValue") VALUES
+            ('theme', 'dark'),
+            ('retryInterval', '30');
+
+            INSERT INTO hdb_catalog."AuditLog" ("action", "userId") VALUES
+            ('System Start', NULL),
+            ('Initial Configuration', NULL);
+
+            CREATE TABLE "Team" (
+              "id" SERIAL PRIMARY KEY
+            );
+            CREATE TABLE "Player" (
+              "id" BIGSERIAL PRIMARY KEY,
+              "teamId" integer NOT NULL REFERENCES "Team"("id"),
+              "name" text NOT NULL
+            );
+            CREATE TABLE "Game" (
+              "id" INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+            );
+          `,
+          snapletConfig,
+          seedScript,
+        });
+        expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+        expect(
+          (await db.query('SELECT * FROM hdb_catalog."AuditLog"')).length,
+        ).toEqual(2);
+        expect(
+          (await db.query('SELECT * FROM hdb_catalog."SystemSettings"')).length,
+        ).toEqual(2);
+        // Should be able to re-run the seed script again thanks to the $resetDatabase
+        await runSeedScript(seedScript);
+        expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+      });
+
+      test("should not reset config excluded table", async () => {
+        const snapletConfig = `
+        import { defineConfig } from "@snaplet/seed/config";
+
+        export default defineConfig({
+          select: {
+            "hdb_catalog.SystemSettings": false,
+          },
+        })
+  `;
+        const seedScript = `
+        import { createSeedClient } from "#seed"
+        const seed = await createSeedClient()
+        await seed.$resetDatabase()
+        await seed.teams((x) => x(2, {
+          players: (x) => x(3)
+        }));
+        await seed.games((x) => x(3));
+      `;
+        const { db, runSeedScript } = await setupProject({
+          adapter,
+          databaseSchema: `
+            CREATE SCHEMA IF NOT EXISTS hdb_catalog;
+            CREATE TABLE hdb_catalog."SystemSettings" (
+              "settingKey" VARCHAR(255) PRIMARY KEY,
+              "settingValue" TEXT NOT NULL
+            );
+
+            CREATE TABLE hdb_catalog."AuditLog" (
+              "logId" SERIAL PRIMARY KEY,
+              "action" TEXT NOT NULL,
+              "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+              "userId" INTEGER
+            );
+
+            INSERT INTO hdb_catalog."SystemSettings" ("settingKey", "settingValue") VALUES
+            ('theme', 'dark'),
+            ('retryInterval', '30');
+
+            INSERT INTO hdb_catalog."AuditLog" ("action", "userId") VALUES
+            ('System Start', NULL),
+            ('Initial Configuration', NULL);
+
+            CREATE TABLE "Team" (
+              "id" SERIAL PRIMARY KEY
+            );
+            CREATE TABLE "Player" (
+              "id" BIGSERIAL PRIMARY KEY,
+              "teamId" integer NOT NULL REFERENCES "Team"("id"),
+              "name" text NOT NULL
+            );
+            CREATE TABLE "Game" (
+              "id" INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+            );
+          `,
+          snapletConfig,
+          seedScript,
+        });
+        expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+        expect(
+          (await db.query('SELECT * FROM hdb_catalog."AuditLog"')).length,
+        ).toEqual(0);
+        expect(
+          (await db.query('SELECT * FROM hdb_catalog."SystemSettings"')).length,
+        ).toEqual(2);
+        // Should be able to re-run the seed script again thanks to the $resetDatabase
+        await runSeedScript(seedScript);
+        expect((await db.query('SELECT * FROM "Player"')).length).toEqual(6);
+      });
+    });
   },
   {
     timeout: 45000,

--- a/packages/seed/src/core/dataModel/select.ts
+++ b/packages/seed/src/core/dataModel/select.ts
@@ -95,7 +95,7 @@ function filterOutChildrenRelations(
   for (const [key, model] of Object.entries(models)) {
     const groupedFields = groupFields(model.fields);
     const childFields = groupedFields.children.filter((field) =>
-      includedTableIds.has(field.type),
+      includedTableIds.has(models[field.type].id),
     );
     result[key] = {
       ...model,
@@ -133,9 +133,9 @@ export function getSelectFilteredDataModel(
     enums: dataModel.enums,
   };
   // We rebuild the data model with only the included tables
-  for (const [id, model] of Object.entries(relationsFilteredDataModel)) {
-    if (includedTables.has(id)) {
-      filteredDataModel.models[id] = model;
+  for (const [key, model] of Object.entries(relationsFilteredDataModel)) {
+    if (includedTables.has(model.id)) {
+      filteredDataModel.models[key] = model;
     }
   }
   return filteredDataModel;

--- a/packages/seed/test/runSeedScript.ts
+++ b/packages/seed/test/runSeedScript.ts
@@ -1,6 +1,6 @@
 import c from "ansi-colors";
 import { execa } from "execa";
-import { mkdirp, symlink, writeFile } from "fs-extra";
+import { mkdirp, pathExists, symlink, writeFile } from "fs-extra";
 import path from "node:path";
 import tmp from "tmp-promise";
 import { expect } from "vitest";
@@ -65,7 +65,10 @@ export const runSeedScript = async ({
   );
 
   await mkdirp(path.dirname(snapletSeedDestPath));
-  await symlink(ROOT_DIR, snapletSeedDestPath);
+
+  if (!(await pathExists(snapletSeedDestPath))) {
+    await symlink(ROOT_DIR, snapletSeedDestPath);
+  }
 
   await writeFile(
     tsConfigPath,


### PR DESCRIPTION
## Ported over
* [seed.$reset works as expected](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1619)
* [seed.$transaction works as expected](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1647)
* [$resetDatabase > should reset all schemas and tables per default](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1154)
* [$resetDatabase > should not reset config excluded schema](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1315)
* [$resetDatabase > should not reset config excluded table](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1399)
* [async column generate callbacks](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L2170)

## Notes
* Did not port over: [$resetDatabase > should reset all "structure" schemas per default](https://github.com/snaplet/snaplet/blob/5d819e317dccf7798c74318f6f0032af8fdaa3a8/cli/e2e/e2e.generate.test.ts#L1228)
  * Reason: "structure" API wasn't ported over to the new repo (I think it is probably no longer relevant in `@snaplet/seed`-specific context), so this e2e tests is not relevant to this repo
* Since postgres has schemas but sqlite doesn't:
  * In `e2e.postgres.test.ts` I ported over the `$resetDatabase` tests here (where they are run only for postgres)
  * In `e2e.api.test.ts`, I wrote new tests to cover the same behaviour as the old repo's `$resetDatabase` tests for cases relevant to both sqlite and postgres (i.e. behaviour not related to schemas)