### PR TITLE
fix(cli): sync installed snaplet/seed version with cli release

### DIFF
--- a/packages/seed/src/cli/commands/init/installDependencies.ts
+++ b/packages/seed/src/cli/commands/init/installDependencies.ts
@@ -3,14 +3,16 @@ import {
   getPackageManager,
   getRootPath,
 } from "#config/utils.js";
+import { getVersion } from "#core/version.js";
 import { spinner } from "../../lib/output.js";
 
 export async function installDependencies() {
   const installedDependencies = await getInstalledDependencies();
 
-  const devDependenciesToInstall = ["@snaplet/copycat", "@snaplet/seed"].filter(
-    (d) => !installedDependencies[d],
-  );
+  const devDependenciesToInstall = [
+    "@snaplet/copycat",
+    `@snaplet/seed@${getVersion()}`,
+  ].filter((d) => !installedDependencies[d]);
 
   if (devDependenciesToInstall.length === 0) {
     return;


### PR DESCRIPTION
Actually when we `npx @snaplet/seed@alpha init` we install a `@snaplet/seed` dependency not matching the one in the alpha channel.

To avoid that, we should always install the same version as the one that is currently deployed on the cli.