### PR TITLE
fix: Fix shape examples for the case of array types

### DIFF
--- a/packages/seed/src/core/userModels/encloseValueInArray.ts
+++ b/packages/seed/src/core/userModels/encloseValueInArray.ts
@@ -1,0 +1,9 @@
+export function encloseValueInArray(value: string, dimensions: number) {
+  if (dimensions === 0) {
+    return value;
+  }
+
+  return Array(dimensions)
+    .fill(undefined)
+    .reduce<string>((acc) => `[${acc}]`, value);
+}

--- a/packages/seed/src/core/userModels/templates/codegen.ts
+++ b/packages/seed/src/core/userModels/templates/codegen.ts
@@ -1,22 +1,13 @@
 import { type NestedType } from "#core/dialect/types.js";
 import { unpackNestedType } from "#core/dialect/unpackNestedType.js";
 import { type Shape } from "#trpc/shapes.js";
+import { encloseValueInArray } from "../encloseValueInArray.js";
 import {
   type TemplateContext,
   type TemplateFn,
   type TemplateInput,
   type Templates,
 } from "./types.js";
-
-function encloseValueInArray(value: string, dimensions: number) {
-  if (dimensions === 0) {
-    return value;
-  }
-
-  return Array(dimensions)
-    .fill(undefined)
-    .reduce<string>((acc) => `[${acc}]`, value);
-}
 
 export const generateCodeFromTemplate = <Type extends string>(props: {
   input: TemplateInput;


### PR DESCRIPTION
When generating the code we use for model defaults, if the field type is an array type, we wrap it in `[]`s. Except we only do this for cases when we generate code from templates at the moment, and not also for the case where we use the shape examples.