### PR TITLE
fix: Allow null overrides for field data

### DIFF
--- a/packages/seed/e2e/e2e.test.ts
+++ b/packages/seed/e2e/e2e.test.ts
@@ -467,5 +467,33 @@ describe.each(adapterEntries)(
       ]);
       expect(yoLos.length).toEqual(1);
     });
+
+    test("null field overrides", async () => {
+      const { db } = await setupProject({
+        adapter,
+        databaseSchema: `
+          CREATE TABLE "Tmp" (
+            "value" text
+          );
+        `,
+        seedScript: `
+          import { createSeedClient } from '#seed'
+
+          const seed = await createSeedClient({
+            models: {
+              tmps: {
+                data: {
+                  value: null,
+                }
+              }
+            }
+          })
+
+          await seed.tmps([{}])
+        `,
+      });
+
+      expect(await db.query('select * from "Tmp"')).toEqual([{ value: null }]);
+    });
   },
 );

--- a/packages/seed/src/core/userModels/userModels.ts
+++ b/packages/seed/src/core/userModels/userModels.ts
@@ -44,7 +44,7 @@ const mergeUserModelsData = (
   const keys = dedupePreferLast([...Object.keys(data1), ...Object.keys(data2)]);
 
   for (const key of keys) {
-    results[key] = data2[key] ?? data1[key];
+    results[key] = Object.hasOwn(data2, key) ? data2[key] : data1[key];
   }
 
   return results;


### PR DESCRIPTION
Currently if the user gives:

```
createSeedClient({
  models: {
    foos: {
      data: {
        bar: null
      }
    }
  }
})
```

The `bar: null` won't be used, and the generated data will be used instead.

This was blocking using snaplet's seed.mts in non-dry mode.