### PR TITLE
fix: keep json imports retrocompatibles

### DIFF
--- a/packages/seed/src/core/codegen/codegen.ts
+++ b/packages/seed/src/core/codegen/codegen.ts
@@ -24,7 +24,7 @@ export interface CodegenContext {
   shapePredictions: Array<TableShapePredictions>;
 }
 
-const FILES = {
+export const FILES = {
   PKG: {
     name: "package.json",
     template() {
@@ -48,11 +48,16 @@ const FILES = {
     template({ dialect, seedConfigPath }: CodegenContext) {
       return dedent`
         import { readFileSync } from "node:fs";
-        import { resolve, join } from "node:path";
+        import { dirname, join } from "node:path";
+        import { fileURLToPath } from "node:url";
+
         import { getSeedClient } from "@snaplet/seed/dialects/${dialect.id}/client";
         import { userModels } from "./${FILES.USER_MODELS.name}";
 
-        const dataModel = JSON.parse(readFileSync(resolve(join(__dirname, "${FILES.USER_MODELS.name}"))));
+        const __filename = fileURLToPath(import.meta.url);
+        const __dirname = dirname(__filename);
+
+        const dataModel = JSON.parse(readFileSync(join(__dirname, "${FILES.DATA_MODEL.name}")));
 
         const seedConfigPath = "${seedConfigPath}";
 

--- a/packages/seed/src/core/codegen/userModels/generateUserModels.ts
+++ b/packages/seed/src/core/codegen/userModels/generateUserModels.ts
@@ -19,6 +19,7 @@ import { type Shape, type TableShapePredictions } from "#trpc/shapes.js";
 import { shouldGenerateFieldValue } from "../../dataModel/shouldGenerateFieldValue.js";
 import { unpackNestedType } from "../../dialect/unpackNestedType.js";
 import { encloseValueInArray } from "../../userModels/encloseValueInArray.js";
+import { FILES } from "../codegen.js";
 import { generateJsonField } from "./generateJsonField.js";
 
 const SHAPE_PREDICTION_CONFIDENCE_THRESHOLD = 0.65;
@@ -243,11 +244,15 @@ export const generateUserModels = (context: CodegenContext) => {
     ) ?? "";
   return dedent`
     import { readFileSync } from "node:fs";
-    import { resolve, join } from "node:path";
+    import { dirname, join } from "node:path";
+    import { fileURLToPath } from "node:url";
     import { copycat } from "@snaplet/copycat";
     import { FallbackSymbol } from "@snaplet/seed/core/symbols";
 
-    const dataExamples = JSON.parse(readFileSync(resolve(join(__dirname, "dataExamples.json"))));
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    const dataExamples = JSON.parse(readFileSync(join(__dirname, "${FILES.DATA_EXAMPLES.name}")));
 
     const getCustomExamples = (input) => dataExamples.find((e) => e.input === input)?.examples ?? [];
     const getExamples = (shape) => dataExamples.find((e) => e.shape === shape)?.examples ?? [];

--- a/packages/seed/src/core/predictions/shapeExamples/getDataExamples.ts
+++ b/packages/seed/src/core/predictions/shapeExamples/getDataExamples.ts
@@ -2,6 +2,7 @@ import { pathExists } from "fs-extra/esm";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getDotSnapletPath } from "#config/dotSnaplet.js";
+import { FILES } from "../../codegen/codegen.js";
 import { type DataExample } from "../types.js";
 
 export async function getDataExamples(): Promise<Array<DataExample>> {
@@ -10,7 +11,7 @@ export async function getDataExamples(): Promise<Array<DataExample>> {
   const dotSnapletPath = await getDotSnapletPath();
 
   if (dotSnapletPath) {
-    const dataExamplesPath = join(dotSnapletPath, "dataExamples.json");
+    const dataExamplesPath = join(dotSnapletPath, FILES.DATA_EXAMPLES.name);
 
     if (await pathExists(dataExamplesPath)) {
       dataExamples = JSON.parse(

--- a/packages/seed/src/core/predictions/shapeExamples/setDataExamples.ts
+++ b/packages/seed/src/core/predictions/shapeExamples/setDataExamples.ts
@@ -3,11 +3,12 @@ import { join } from "node:path";
 import { ensureDotSnapletPath } from "#config/dotSnaplet.js";
 import { type DataExample } from "#core/predictions/types.js";
 import { jsonStringify } from "#core/utils.js";
+import { FILES } from "../../codegen/codegen.js";
 
 export async function setDataExamples(shapeExamples: Array<DataExample>) {
   const dotSnapletPath = await ensureDotSnapletPath();
 
-  const shapeExamplesPath = join(dotSnapletPath, "dataExamples.json");
+  const shapeExamplesPath = join(dotSnapletPath, FILES.DATA_EXAMPLES.name);
 
   await writeFile(
     shapeExamplesPath,


### PR DESCRIPTION
Using the new `with` syntax break usage with  most of the versions of node < 21 with little benefit. Rollback to the good old `readFileSync+JSON.parse` instead.