### PR TITLE
fix(core): enable autocomplete for SelectOptions in config

### DIFF
--- a/packages/seed/src/core/codegen/generateConfigTypes.ts
+++ b/packages/seed/src/core/codegen/generateConfigTypes.ts
@@ -20,7 +20,7 @@ export function generateSelectTypeFromTableIds(
     uniqueTableIds.length > 0
       ? [
           `type TablesOptions = ${EOL}${uniqueTableIds.map((id) => `  "${id}"`).join(` |${EOL}`)}${EOL}`,
-          `type SelectOptions = TablesOptions | string`,
+          `type SelectOptions = TablesOptions | (string & {})`,
         ].join(EOL)
       : `type SelectOptions = string`;
 


### PR DESCRIPTION
Using only `string` wasn't working, it erased the other union members.