### PR TITLE
fix: Fix types for `connect` for composite primary key

### DIFF
--- a/packages/seed/src/core/codegen/generateClientTypes.ts
+++ b/packages/seed/src/core/codegen/generateClientTypes.ts
@@ -500,12 +500,12 @@ ${fields.children
 
   const scalarsInputsType =
     generatedFields.length > 0
-      ? `Omit<${modelName}Scalars, "${generatedFields.join(" | ")}">`
+      ? `Omit<${modelName}Scalars, "${generatedFields.join('" | "')}">`
       : `${modelName}Scalars`;
 
   const connectScalarsType =
     idFields.length > 0
-      ? `Pick<${modelName}Scalars, "${idFields.join(" | ")}"> & Partial<Omit<${modelName}Scalars, "${idFields.join(" | ")}">>`
+      ? `Pick<${modelName}Scalars, "${idFields.join('" | "')}"> & Partial<Omit<${modelName}Scalars, "${idFields.join('" | "')}">>`
       : `Partial<${modelName}Scalars>`;
 
   const extraTypes = `type ${modelName}Inputs = Inputs<

--- a/packages/seed/test/setupProject.ts
+++ b/packages/seed/test/setupProject.ts
@@ -118,17 +118,19 @@ async function seedSetup(props: {
 
   const runSeedScript = async (
     script: string,
-    options?: { env?: Record<string, string> },
+    options?: {
+      delete?: boolean;
+      env?: Record<string, string>;
+    },
   ) => {
-    const runScriptResult = await baseRunSeedScript({
+    return baseRunSeedScript({
       script,
       adapter: props.adapter,
       cwd,
       connectionString: props.connectionString,
       env: options?.env,
+      delete: options?.delete,
     });
-
-    return runScriptResult;
   };
 
   let stdout = "";


### PR DESCRIPTION
We were generating types that looked like `"id1 | id2"` instead of `"id1" | "id2"`.

Also adds corresponding e2e tests.