### PR TITLE
CI disable telemetry

### DIFF
--- a/packages/seed/src/config/constants.ts
+++ b/packages/seed/src/config/constants.ts
@@ -1,5 +1,18 @@
+import { basename, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 export const SNAPLET_API_URL =
   process.env["SNAPLET_API_URL"] ?? "https://api.snaplet.dev/cli";
 
 export const SNAPLET_APP_URL =
   process.env["SNAPLET_APP_URL"] ?? "https://app.snaplet.dev";
+
+// context(justinvdm, 19 Mar 2024): We need a way to determine whether
+// we are in dev (our dev, not user dev). We build using tsc, so
+// we can't use env var replacement like we would do with esbuild or webpack.
+// So instead we check whether we are using src (dev - this would be the case
+// for our test runs) or dist (production)
+export const IS_PRODUCTION = basename(dirname(dirname(__dirname))) !== "src";

--- a/packages/seed/src/core/telemetry/telemetry.ts
+++ b/packages/seed/src/core/telemetry/telemetry.ts
@@ -3,6 +3,7 @@ import deepmerge from "deepmerge";
 import os from "node:os";
 import { PostHog } from "posthog-node";
 import { v4 as uuidv4 } from "uuid";
+import { IS_PRODUCTION } from "#config/constants.js";
 import { getProjectConfig } from "#config/project/projectConfig.js";
 import { getSystemConfig, updateSystemConfig } from "#config/systemConfig.js";
 
@@ -43,7 +44,11 @@ const getDistinctId = async () => {
 export const createTelemetry = (options: TelemetryOptions) => {
   let posthog: PostHog | null = null;
 
-  const { source, properties: baseProperties = () => ({}) } = options;
+  const {
+    source,
+    properties: baseProperties = () => ({}),
+    isProduction = IS_PRODUCTION,
+  } = options;
 
   const initPosthog = () =>
     (posthog ??= new PostHog(POSTHOG_API_KEY, {
@@ -52,7 +57,7 @@ export const createTelemetry = (options: TelemetryOptions) => {
       flushInterval: 0,
     }));
 
-  if (process.env["SNAPLET_DISABLE_TELEMETRY"] !== "1") {
+  if (process.env["SNAPLET_DISABLE_TELEMETRY"] !== "1" && isProduction) {
     initPosthog();
   }
 


### PR DESCRIPTION
Our e2e tests avoid sending telemetry already, but there seems to be some that still send (might be our install e2e tests)

As a failsafe, this PR adds an env var to our github workflow config to avoid sending telemetry.