### PR TITLE
feat: Track version as property in analytics events

### DIFF
--- a/packages/seed/src/core/telemetry/telemetry.ts
+++ b/packages/seed/src/core/telemetry/telemetry.ts
@@ -86,6 +86,12 @@ export const createTelemetry = (options: TelemetryOptions) => {
     });
   };
 
+  const getIsAnonymous = async () => {
+    const distinctId = await getDistinctId();
+    const { anonymousId } = await getSystemConfig();
+    return distinctId === anonymousId;
+  };
+
   const captureEvent = async (
     event: string,
     properties: Record<string, unknown> = {},
@@ -96,6 +102,7 @@ export const createTelemetry = (options: TelemetryOptions) => {
       ...properties,
       source,
       version: `seed@${getVersion()}`,
+      isAnonymous: await getIsAnonymous(),
       isCI: ci.isCI,
       ci: {
         isPR: ci.isPR,


### PR DESCRIPTION
Adds `version` property (read from `package.json`) to all analytics events.

<img width="1154" alt="Screenshot 2024-04-25 at 15 09 36" src="https://github.com/snaplet/seed/assets/1731223/9cfc33f0-0005-4f71-95f2-8cd6977adc94">
<img width="1166" alt="Screenshot 2024-04-25 at 15 09 56" src="https://github.com/snaplet/seed/assets/1731223/9dae8f8a-0ff4-4837-863f-750bda094667">

