### PR TITLE
fix: better-sqlite3 database arguments

### DIFF
--- a/packages/seed/src/adapters/better-sqlite3/better-sqlite3.ts
+++ b/packages/seed/src/adapters/better-sqlite3/better-sqlite3.ts
@@ -23,7 +23,9 @@ export const betterSqlite3Adapter = {
   name: "better-sqlite3",
   packageName: "better-sqlite3",
   typesPackageName: "@types/better-sqlite3",
-  template: (parameters = `'<your-database-path>', { fileMustExist: true }`) => dedent`
+  template: (
+    parameters = `'<your-database-path>', { fileMustExist: true }`,
+  ) => dedent`
     import { SeedBetterSqlite3 } from "@snaplet/seed/adapter-better-sqlite3";
     import { defineConfig } from "@snaplet/seed/config";
     import Database from "better-sqlite3";


### PR DESCRIPTION
- Change the default parameters for `better-sqlite3` so we actually attempt connection rather than creation

I've tough about also waiting to have a valid introspection before exiting the loop, but that was making the logic leak quite a bit and starting to look spaghetti. So I have opted for keeping the separations of concerns as it is.

Fixes S-2093