### PR TITLE
feat: Add telemetry for init steps

### DIFF
--- a/packages/seed/src/cli/commands/init/initHandler.ts
+++ b/packages/seed/src/cli/commands/init/initHandler.ts
@@ -100,7 +100,7 @@ export async function initHandler(args: {
   }
 
   await telemetry.captureEvent("$action:init:step:config", {
-    hadSeedConfig,
+    hadConfig: hadSeedConfig,
     isLoggedIn,
   });
 


### PR DESCRIPTION
* `$action:init:step:authChosen`: Fired after user given choice of using Snaplet AI
  * `choice`: Their choice

* `$action:init:step:authDone`: Fired after the auth step is complete (or if they skipped it since they're logged out)
  * `isLoggedIn`: whether they are now logged in
  * `wasLoggedIn`: whether they were previously logged in
  
* `$action:init:step:afterLink`: Fired after project linking step is complete (or if it was skipped since logged out)
  * `didLink`: whether they did link
  * `isLoggedIn`: whether they are logged in
  
 * `$action:init:step:adapter`: Fired after adapter has been retrieved (either because user selected it, or if it was already in config)
   * `adapter`: Name of the adapter they are now using
   * `hadAdapter`: Whether previously had an adapter in config
   * `isLoggedIn`: whether they are logged in
   
 * `$action:init:step:config`: fired after the user completed config step
   * `hadConfig`: whether they previously had config
   * `isLoggedIn`: whether they are logged in
   
 * `$action:init:step:sync`: fired after the sync step completed as part of init
   * `isLoggedIn`: whether they are logged in