### PR TITLE
:bug: Allow loosely false values to not violate unique constraints not jus…

### DIFF
--- a/packages/seed/src/core/plan/constraints.ts
+++ b/packages/seed/src/core/plan/constraints.ts
@@ -92,9 +92,8 @@ export async function checkConstraints(
   const sortedConstraints = sortBy(filteredConstraints, (c) => c.fields.length);
 
   for (const constraint of sortedConstraints) {
-    // We skip the constraint if it contains null values
-    if (
-      constraint.fields.some((c) => props.modelData[c] === null) &&
+    // We skip the constraint if it contains nullish values
+    if (!constraint.fields.some((c) => props.modelData[c]) &&
       // Execpt if the constraint is nullNotDistinct so each null values isn't considered distinct
       // from the other null values anymore (maximum one null value is allowed)
       !constraint.nullNotDistinct


### PR DESCRIPTION
This fixes https://github.com/supabase-community/seed/issues/191 by allowing loosely false values, not just strictly null values to be used in fields with unique constraints.  

This resolves a problem with Supabase auth whereby it blocks multiple users having the same recovery_token (and other columns) which need to all be the empty string.
